### PR TITLE
Add backup label for external managed kubeconfig in local clusters

### DIFF
--- a/pkg/controller/hosted/manifests/external_managed_secret.yaml
+++ b/pkg/controller/hosted/manifests/external_managed_secret.yaml
@@ -3,6 +3,10 @@ kind: Secret
 metadata:
   name: "external-managed-kubeconfig"
   namespace: "{{ .KlusterletNamespace }}"
+  {{- if .IsLocalCluster }}
+  labels:
+    cluster.open-cluster-management.io/backup: "import-controller"
+  {{- end }}
 type: Opaque
 data:
   kubeconfig: {{ .ExternalManagedKubeconfig }}


### PR DESCRIPTION
## Summary
- Add backup label to external-managed-kubeconfig secret when hosting cluster is local
- Check for local-cluster label on hosting cluster to determine if backup label should be applied
- Ensure proper backup handling for import controller secrets

## Test plan
- Verify that external-managed-kubeconfig secrets get backup label when hosting cluster has local-cluster=true
- Test that secrets without local hosting cluster do not get the backup label
- Confirm existing functionality remains unchanged

Signed-off-by: daliu@redhat.com